### PR TITLE
Remove old project related links, names, preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Advantages to w3mimgdisplay:
   * [Libraries](#libraries)
     + [~~Bash~~ (deprecated)](#bash)
     + [Python](#python)
-    + [Python Urwid](https://github.com/seebye/urwid-ueberzogen)
   * [Examples](#examples)
 
 
@@ -310,6 +309,5 @@ Python library:
 
 Scripts:
 
-- fzf with image preview: https://github.com/seebye/ueberzug/blob/master/examples/fzfimg.sh
-- Mastodon viewer: https://github.com/seebye/ueberzug/blob/master/examples/mastodon.sh
-- **F**zf **M**pd **U**ser **I**nterface: https://github.com/seebye/fmui
+- fzf with image preview: https://github.com/ueber-devel/ueberzug/blob/master/examples/fzfimg.sh
+- Mastodon viewer: https://github.com/ueber-devel/ueberzug/blob/master/examples/mastodon.sh

--- a/examples/fzfimg.sh
+++ b/examples/fzfimg.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # This is just an example how ueberzug can be used with fzf.
-# Copyright (C) 2019  seebye
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/examples/mastodon.sh
+++ b/examples/mastodon.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # This is just an example how ueberzug can be used.
-# Copyright (C) 2019  seebye
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,1 +1,0 @@
-I don't accept pull requests.

--- a/ueberzug/__init__.py
+++ b/ueberzug/__init__.py
@@ -1,7 +1,7 @@
 __version__ = '18.1.9'
 __license__ = 'GPLv3'
 __description__ ='ueberzug is a command line util which allows to display images in combination with X11'
-__url_repository__ = 'https://github.com/seebye/ueberzug'
-__url_bug_reports__ = 'https://github.com/seebye/ueberzug/issues'
+__url_repository__ = 'https://github.com/ueber-devel/ueberzug'
+__url_bug_reports__ = 'https://github.com/ueber-devel/ueberzug/issues'
 __url_project__ = __url_repository__
-__author__ = 'seebye'
+__author__ = ''

--- a/ueberzug/__main__.py
+++ b/ueberzug/__main__.py
@@ -27,7 +27,7 @@ Layer options:
 
 
 License:
-    ueberzug  Copyright (C) 2018  seebye
+    ueberzug
     This program comes with ABSOLUTELY NO WARRANTY.
     This is free software, and you are welcome to redistribute it
     under certain conditions.


### PR DESCRIPTION
As it is requested from the old authors this commit removes their names from the project. Some of the links also modified to follow current project.

Also removing the template which states pull requests are not accepted.
