### PR TITLE
recusively query window tree

### DIFF
--- a/ueberzug/X/display.c
+++ b/ueberzug/X/display.c
@@ -139,8 +139,9 @@ Display_get_child_window_ids(DisplayObject *self, PyObject *args, PyObject *kwds
         Py_RETURN_ERROR;
     }
 
-    get_child_window_ids_helper(self->info_display, parent, &children, &children_count);
+    get_child_window_ids_helper(self->info_display, parent, &children, &children_count, &xtree_return);
     if (!xtree_return) {
+        free(children);
         raise(OSError, "failed to query child windows of %lu", parent);
     }
 


### PR DESCRIPTION
After seebye release version 18.1.9 , he switched from python-xlib to xres and xshm. This change caused the ueberzug window to not appear in certain conditions where the ueberzug process was deeply nested. as in
`suckless tabbed -> tmux -> ueberzug` or `i3 tabs -> tmux -> ueberzug`, this is caused because the window tree was only being used to get the first level of windows and not any child windows.

This PR fixes this issue.