### PR TITLE
support single proc terms

### DIFF
--- a/ueberzug/xutil.py
+++ b/ueberzug/xutil.py
@@ -1,6 +1,7 @@
 """This module contains x11 utils"""
 import functools
 import asyncio
+import os
 
 import ueberzug.tmux_util as tmux_util
 import ueberzug.terminal as terminal
@@ -126,6 +127,10 @@ def get_parent_window_infos(display: X.Display):
 
     if client_pids:
         pid_window_id_map = get_pid_window_id_map(display)
+        # Insert current window's PID & WID to the end of map to support tabbed.
+        # NOTE: Terminal (current window) must have WINDOWID as env. variable.
+        if (os.environ.get('WINDOWID') != None):
+            pid_window_id_map[os.getpid()] = int(os.environ.get('WINDOWID'))
 
         for pid in client_pids:
             ppids = get_parent_pids(pid)


### PR DESCRIPTION
welp, went checking in with multiple terminals that are single process, urxvt (daemon), xfce4-terminal, mate-terminal, gnome-terminal.

the only caveat remaining is that tabs on libvte terminals aren't detected so the images linger when you switch tabs i imagine this likely is the same for other terminals that implement tabs, besides that i have not seen any other problem arise with single process terminals.