### PR TITLE
reduce distutils dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import distutils.core
 import setuptools
+import distutils.core
 import glob
 
 import ueberzug

--- a/ueberzug/conversion.py
+++ b/ueberzug/conversion.py
@@ -1,3 +1,38 @@
+# extracted from distutils
+# under license: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+#
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError(f"invalid truth value {val!r}")
 
 
 def to_bool(value):
@@ -9,6 +44,5 @@ def to_bool(value):
     Returns:
         bool: the evaluated boolean
     """
-    import distutils.util
     return (value if isinstance(value, bool)
-            else bool(distutils.util.strtobool(value)))
+            else bool(strtobool(value)))


### PR DESCRIPTION
addressing #19 
not truly moving away from distutils yet, just reducing the dependency.

full move away from distutils will come when i move the project to meson for a proper build system soon™

todo:
- [x] change import order for distutils
- [x] add the distutils.util.strtobool function to the ueberzug codebase to not depend on the library