### PR TITLE
Fix process name matching to include newlines

### DIFF
--- a/ueberzug/process.py
+++ b/ueberzug/process.py
@@ -51,6 +51,7 @@ def get_info(pid: int):
             rb"(?P<session>[-+]?\d+) "
             rb"(?P<tty_nr>[-+]?\d+)",
             data,
+            re.DOTALL,
         ).groupdict()
 
 


### PR DESCRIPTION
It is possible for process name to include a new line, especially under tmux where the name can be set by terminal escape codes and may get a newline by accident.