### PR TITLE
Handle escaped '$' characters using bash parser

### DIFF
--- a/ueberzug/layer.py
+++ b/ueberzug/layer.py
@@ -37,8 +37,7 @@ async def process_commands(
                 break
 
             try:
-                line = re.sub("\\\\", "", line)
-
+                line = re.sub("\\\\[$]", "$", line)
                 data = tools.parser.parse(line[:-1])
                 command = action.Command(data["action"])
                 await command.action_class(**data).apply(windows, view, tools)


### PR DESCRIPTION
Issue #25 pointed out a failure when the bash parser tries to escape `$` characters in a filename. That needs to be handled properly without touching other escaped characters.